### PR TITLE
Update base.rs.

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1,84 +1,108 @@
-use libc::size_t;
-use std::os::raw::{c_char, c_ushort};
+use libc::{c_char, size_t};
+use std::{marker::PhantomData, os::raw::{c_ushort}};
 
-/// A read-only view on a Rust utf-8 string or byte array.
+/// A read-only view on a Rust byte slice.
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API.
+/// `len` indicates the number of bytes than can be safely read.
+/// A `len` of 0 is used to represent a missing value OR an empty slice.
+///
+/// The memory exposed is available for the duration of the call (e.g.
+/// when passed to a callback) and must be copied if the values are
+/// needed for longer.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct rustls_slice_bytes<'a> {
+    data: *const u8,
+    len: size_t,
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> From<&'a [u8]> for rustls_slice_bytes<'a> {
+    fn from(s: &[u8]) -> Self {
+        rustls_slice_bytes {
+            data: s.as_ptr() as *const u8,
+            len: s.len() as size_t,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// A read-only view on a vector of Rust byte slices.
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API. The `data` is an array of `rustls_slice_bytes`
+/// structures with `len` elements.
+///
+/// The memory exposed is available for the duration of the call (e.g.
+/// when passed to a callback) and must be copied if the values are
+/// needed for longer.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct rustls_vec_slice_bytes<'a> {
+    data: *const rustls_slice_bytes<'a>,
+    len: size_t,
+}
+
+impl<'a> From<&'a [&[u8]]> for rustls_vec_slice_bytes<'a> {
+    fn from(input: &'a [&[u8]]) -> Self {
+        let mut output: Vec<rustls_slice_bytes> = vec![];
+        for b in input {
+            let b: &[u8] = b;
+            output.push(b.into());
+        }
+        rustls_vec_slice_bytes {
+            data: output.as_ptr(),
+            len: output.len(),
+        }
+    }
+}
+
+/// A read-only view on a Rust utf-8 string slice.
 /// This is used to pass data from crustls to callback functions provided
 /// by the user of the API. The `data` is not NUL-terminated.
 /// `len` indicates the number of bytes than can be safely read.
-/// A `len` of 0 is used to represent a missing value.
+/// A `len` of 0 is used to represent a missing value OR an empty string.
 ///
-/// The memmory exposed is available for the duration of the call (e.g.
+/// The memory exposed is available for the duration of the call (e.g.
 /// when passed to a callback) and must be copied if the values are
 /// needed for longer.
-///
 #[allow(non_camel_case_types)]
 #[repr(C)]
-pub struct rustls_string {
+pub struct rustls_str<'a> {
     data: *const c_char,
     len: size_t,
+    phantom: PhantomData<&'a str>,
 }
 
-impl<'a> From<&'a String> for rustls_string {
-    fn from(s: &String) -> Self {
-        rustls_string {
-            data: s.as_ptr() as *const c_char,
-            len: s.len() as size_t,
-        }
-    }
-}
-
-impl<'a> From<&'a str> for rustls_string {
+impl<'a> From<&'a str> for rustls_str<'a> {
     fn from(s: &str) -> Self {
-        rustls_string {
+        rustls_str {
             data: s.as_ptr() as *const c_char,
             len: s.len() as size_t,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a> From<&'a [u8]> for rustls_string {
-    fn from(s: &[u8]) -> Self {
-        rustls_string {
-            data: s.as_ptr() as *const c_char,
-            len: s.len() as size_t,
-        }
-    }
-}
-
-pub(crate) fn rustls_strings<'a>(values: Option<&'a [&'a [u8]]>) -> Vec<rustls_string> {
-    let mut strings: Vec<rustls_string> = Vec::new();
-    match values {
-        Some(values) => {
-            for entry in values.iter() {
-                strings.push(rustls_string::from(*entry))
-            }
-        }
-        None => (),
-    };
-    strings
-}
-
-/// A read-only view on a list of Rust utf-8 strings or byte arrays.
-/// This is used to pass data from crustls to callback functions provided
-/// by the user of the API. The `data` is an array of `rustls_string`
-/// structures with `len` elements.
-///
-/// The memmory exposed is available for the duration of the call (e.g.
-/// when passed to a callback) and must be copied if the values are
-/// needed for longer.
-///
 #[allow(non_camel_case_types)]
 #[repr(C)]
-pub struct rustls_vec_string {
-    data: *const rustls_string,
+pub struct rustls_vec_str<'a> {
+    data: *const rustls_str<'a>,
     len: size_t,
 }
 
-impl<'a> From<&'a Vec<rustls_string>> for rustls_vec_string {
-    fn from(values: &Vec<rustls_string>) -> Self {
-        rustls_vec_string {
-            data: values.as_ptr(),
-            len: values.len(),
+impl<'a> From<&'a [String]> for rustls_vec_str<'a> {
+    fn from(input: &'a [String]) -> Self {
+        let mut output: Vec<rustls_str> = vec![];
+        for b in input {
+            let b: &str = b;
+            output.push(b.into());
+        }
+        rustls_vec_str {
+            data: output.as_ptr(),
+            len: output.len(),
         }
     }
 }
@@ -87,10 +111,9 @@ impl<'a> From<&'a Vec<rustls_string>> for rustls_vec_string {
 /// This is used to pass data from crustls to callback functions provided
 /// by the user of the API. The `data` is an array of `len` 16 bit values.
 ///
-/// The memmory exposed is available for the duration of the call (e.g.
+/// The memory exposed is available for the duration of the call (e.g.
 /// when passed to a callback) and must be copied if the values are
 /// needed for longer.
-///
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct rustls_vec_ushort {

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -135,31 +135,29 @@ typedef struct rustls_server_session rustls_server_session;
 typedef void *rustls_client_hello_userdata;
 
 /**
- * A read-only view on a Rust utf-8 string or byte array.
+ * A read-only view on a Rust utf-8 string slice.
  * This is used to pass data from crustls to callback functions provided
  * by the user of the API. The `data` is not NUL-terminated.
  * `len` indicates the number of bytes than can be safely read.
- * A `len` of 0 is used to represent a missing value.
+ * A `len` of 0 is used to represent a missing value OR an empty string.
  *
- * The memmory exposed is available for the duration of the call (e.g.
+ * The memory exposed is available for the duration of the call (e.g.
  * when passed to a callback) and must be copied if the values are
  * needed for longer.
- *
  */
-typedef struct rustls_string {
+typedef struct rustls_str {
   const char *data;
   size_t len;
-} rustls_string;
+} rustls_str;
 
 /**
  * A read-only view on a list of Rust owned unsigned short values.
  * This is used to pass data from crustls to callback functions provided
  * by the user of the API. The `data` is an array of `len` 16 bit values.
  *
- * The memmory exposed is available for the duration of the call (e.g.
+ * The memory exposed is available for the duration of the call (e.g.
  * when passed to a callback) and must be copied if the values are
  * needed for longer.
- *
  */
 typedef struct rustls_vec_ushort {
   const unsigned short *data;
@@ -167,20 +165,37 @@ typedef struct rustls_vec_ushort {
 } rustls_vec_ushort;
 
 /**
- * A read-only view on a list of Rust utf-8 strings or byte arrays.
- * This is used to pass data from crustls to callback functions provided
- * by the user of the API. The `data` is an array of `rustls_string`
- * structures with `len` elements.
+ * A read-only view on a Rust byte slice.
  *
- * The memmory exposed is available for the duration of the call (e.g.
+ * This is used to pass data from crustls to callback functions provided
+ * by the user of the API.
+ * `len` indicates the number of bytes than can be safely read.
+ * A `len` of 0 is used to represent a missing value OR an empty slice.
+ *
+ * The memory exposed is available for the duration of the call (e.g.
  * when passed to a callback) and must be copied if the values are
  * needed for longer.
- *
  */
-typedef struct rustls_vec_string {
-  const struct rustls_string *data;
+typedef struct rustls_slice_bytes {
+  const uint8_t *data;
   size_t len;
-} rustls_vec_string;
+} rustls_slice_bytes;
+
+/**
+ * A read-only view on a vector of Rust byte slices.
+ *
+ * This is used to pass data from crustls to callback functions provided
+ * by the user of the API. The `data` is an array of `rustls_slice_bytes`
+ * structures with `len` elements.
+ *
+ * The memory exposed is available for the duration of the call (e.g.
+ * when passed to a callback) and must be copied if the values are
+ * needed for longer.
+ */
+typedef struct rustls_vec_slice_bytes {
+  const struct rustls_slice_bytes *data;
+  size_t len;
+} rustls_vec_slice_bytes;
 
 /**
  * The TLS Client Hello information provided to a ClientHelloCallback function.
@@ -201,9 +216,9 @@ typedef struct rustls_vec_string {
  * the rustls library is re-evaluating their current approach to client hello handling.
  */
 typedef struct rustls_client_hello {
-  struct rustls_string sni_name;
+  struct rustls_str sni_name;
   struct rustls_vec_ushort signature_schemes;
-  struct rustls_vec_string alpn;
+  struct rustls_vec_slice_bytes alpn;
 } rustls_client_hello;
 
 /**


### PR DESCRIPTION
We now have four types that map nicely to Rust types:

 - rustls_str -> &str or &String
 - rustls_slice_bytes -> &[u8] or &Vec<u8>
 - rustls_vec_str -> &[&str] or &Vec<&str>
 - rustls_vec_slice_bytes -> &[&[u8]] or &Vec<Vec<u8>>

I also added lifetime parameters for these types, along with PhantomData
to refer to those lifetime parameters. This lets us take slightly more
advantage of Rust's safety tools by ensuring we don't allow any of these
types to outlive the things they refer to.